### PR TITLE
Add changes to patch for cloud instance type and domain group by's

### DIFF
--- a/patches/federated/configuration.diff
+++ b/patches/federated/configuration.diff
@@ -237,7 +237,12 @@ diff --git a/configuration/datawarehouse.d/ref/Cloud-group-bys.json b/configurat
 index 5be8d75b..d6b88191 100644
 --- a/configuration/datawarehouse.d/ref/Cloud-group-bys.json
 +++ b/configuration/datawarehouse.d/ref/Cloud-group-bys.json
-@@ -8,13 +8,13 @@
+@@ -4,17 +4,17 @@
+         "description_html": "The instance type of a virtual machine.",
+         "attribute_table_schema": "modw_cloud",
+         "alternate_group_by_columns": [
+-            "display"
++            "primaryid"
          ],
          "attribute_to_aggregate_table_key_map": [
              {
@@ -258,18 +263,24 @@ index 5be8d75b..d6b88191 100644
          },
          "attribute_filter_map_query": {
 -            "instance_type_id": "SELECT instance_type_id FROM modw_cloud.instance_type WHERE display IN (__filter_values__)"
-+            "instance_type_id": "SELECT primaryid FROM modw_cloud.instance_type WHERE display IN (__filter_values__)"
++            "instance_type_id": "SELECT primaryid FROM modw_cloud.instance_type WHERE primaryid IN (__filter_values__)"
          },
-         "attribute_description_query": "SELECT DISTINCT display AS filter_name FROM modw_cloud.instance_type WHERE display IN (__filter_values__) ORDER BY display"
+-        "attribute_description_query": "SELECT DISTINCT display AS filter_name FROM modw_cloud.instance_type WHERE display IN (__filter_values__) ORDER BY display"
++        "attribute_description_query": "SELECT DISTINCT display AS filter_name FROM modw_cloud.instance_type WHERE primaryid IN (__filter_values__) ORDER BY display"
      },
-@@ -39,7 +39,7 @@
-             "name"
+@@ -36,10 +36,10 @@
+      },
+      "domain": {
+         "alternate_group_by_columns": [
+-            "name"
++            "primaryid"
          ],
          "attribute_filter_map_query":{
 -            "domain_id": "SELECT id FROM modw_cloud.domains WHERE name IN (__filter_values__)"
-+            "domain_id": "SELECT primayid FROM modw_cloud.domains WHERE name IN (__filter_values__)"
++            "domain_id": "SELECT primaryid FROM modw_cloud.domains WHERE primaryid IN (__filter_values__)"
          },
-         "attribute_description_query": "SELECT DISTINCT name AS filter_name FROM modw_cloud.domains WHERE name IN (__filter_values__) ORDER BY name",
+-        "attribute_description_query": "SELECT DISTINCT name AS filter_name FROM modw_cloud.domains WHERE name IN (__filter_values__) ORDER BY name",
++        "attribute_description_query": "SELECT DISTINCT name AS filter_name FROM modw_cloud.domains WHERE primaryid IN (__filter_values__) ORDER BY name",
          "name": "Domain",
 @@ -54,12 +54,12 @@
          "attribute_table_schema": "modw_cloud",


### PR DESCRIPTION
These changes make use of the `primaryid` field added by this patch in the instance type and domain group by's. Using the `primaryid` field is necessary in order for data to show properly in the metric explorer and in the filters.

## Tests performed
Tested in docker

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project as found in the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
